### PR TITLE
Bump yjs version to support current Node LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "y-text": "^9.5.1",
     "y-webrtc": "^8.0.7",
     "y-websockets-client": "^8.0.16",
-    "yjs": "^12.3.3"
+    "yjs": "^13.0.0-0"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
I was getting the following error on compile with Node@10:

```
8 warnings and 1 error generated.
make: *** [Release/obj.target/validation/src/validation.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:262:23)
gyp ERR! stack     at ChildProcess.emit (events.js:182:13)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:240:12)
gyp ERR! System Darwin 16.7.0
gyp ERR! command "/usr/local/Cellar/node/11.0.0/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd [obfuscated]/node_modules/utf-8-validate
gyp ERR! node -v v11.0.0
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: utf-8-validate@1.2.2 (node_modules/utf-8-validate):
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: utf-8-validate@1.2.2 install: `node-gyp rebuild`
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: Exit status 1
```
It seems the pinned version of yjs depends on upstream package `utf-8-validate@1.2.2`, which is incompatible with Node 10.

Bumping the Yjs version in turn bumps the `utf-8-validate` version, which lets `npm install` suceed. 
